### PR TITLE
Add starter UPS tracker dashboard

### DIFF
--- a/ups-tracker-dashboard/.gitignore
+++ b/ups-tracker-dashboard/.gitignore
@@ -1,0 +1,20 @@
+# Node
+node_modules
+
+# Build output
+build
+.dist
+
+# Optional environment files
+.env*
+
+# Logs
+logs
+*.log
+
+# Next.js / Vite caches
+.next
+.vite
+
+# TypeScript
+*.tsbuildinfo

--- a/ups-tracker-dashboard/api/getDevices.ts
+++ b/ups-tracker-dashboard/api/getDevices.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import { Device } from '../types';
+
+// TODO: Replace mock data with Addigy API integration and authentication
+const mockDevices: Device[] = [
+  {
+    id: '1',
+    name: 'MacBook Pro 14',
+    serialNumber: 'ABC123456',
+    addigyStatus: 'Enrolled',
+    trackingNumber: '1Z999AA10123456784',
+  },
+  {
+    id: '2',
+    name: 'MacBook Air 13',
+    serialNumber: 'XYZ987654',
+    addigyStatus: 'Shipped',
+    trackingNumber: '1Z999AA10123456785',
+  },
+];
+
+export function getDevices(req: Request, res: Response) {
+  // In a real implementation, use Addigy API keys here
+  res.json(mockDevices);
+}

--- a/ups-tracker-dashboard/api/getTracking.ts
+++ b/ups-tracker-dashboard/api/getTracking.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from 'express';
+import { TrackingInfo } from '../types';
+
+// TODO: Replace this mock data with real UPS API calls
+export function getTracking(req: Request, res: Response) {
+  const { trackingNumber } = req.query;
+
+  if (!trackingNumber || typeof trackingNumber !== 'string') {
+    return res.status(400).json({ error: 'trackingNumber query param required' });
+  }
+
+  const mockTracking: TrackingInfo = {
+    trackingNumber,
+    status: 'in_transit',
+    estimatedDelivery: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+  };
+
+  // In a real implementation, insert UPS API key and fetch tracking info here
+  res.json(mockTracking);
+}

--- a/ups-tracker-dashboard/components/DeviceTable.tsx
+++ b/ups-tracker-dashboard/components/DeviceTable.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { Device, TrackingInfo } from '../types';
+import { TrackingStatus } from './TrackingStatus';
+
+interface Props {
+  devices: Device[];
+  trackings: Record<string, TrackingInfo>;
+}
+
+export const DeviceTable: React.FC<Props> = ({ devices, trackings }) => {
+  const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<keyof Device>('name');
+
+  const filtered = devices
+    .filter(d =>
+      d.name.toLowerCase().includes(search.toLowerCase()) ||
+      d.serialNumber.toLowerCase().includes(search.toLowerCase())
+    )
+    .sort((a, b) => {
+      const aVal = a[sortKey] || '';
+      const bVal = b[sortKey] || '';
+      return String(aVal).localeCompare(String(bVal));
+    });
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="Search by name or serial"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        className="border p-2 mb-2 w-full"
+      />
+      <table className="min-w-full table-auto border-collapse">
+        <thead>
+          <tr>
+            <th className="cursor-pointer" onClick={() => setSortKey('name')}>Name</th>
+            <th className="cursor-pointer" onClick={() => setSortKey('serialNumber')}>Serial</th>
+            <th>Status</th>
+            <th>Tracking</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map(device => (
+            <tr key={device.id} className="border-t">
+              <td className="p-2">{device.name}</td>
+              <td className="p-2 font-mono">{device.serialNumber}</td>
+              <td className="p-2">{device.addigyStatus}</td>
+              <td className="p-2">
+                {device.trackingNumber && trackings[device.trackingNumber] ? (
+                  <TrackingStatus tracking={trackings[device.trackingNumber]} />
+                ) : (
+                  'N/A'
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/ups-tracker-dashboard/components/TrackingStatus.tsx
+++ b/ups-tracker-dashboard/components/TrackingStatus.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { TrackingInfo } from '../types';
+import { formatDate } from '../utils/formatDate';
+
+interface Props {
+  tracking: TrackingInfo;
+}
+
+// Displays colored label for delivery status
+export const TrackingStatus: React.FC<Props> = ({ tracking }) => {
+  const statusColors: Record<TrackingInfo['status'], string> = {
+    delivered: 'text-green-600',
+    in_transit: 'text-blue-600',
+    exception: 'text-red-600',
+    unknown: 'text-gray-600',
+  };
+
+  return (
+    <span className={statusColors[tracking.status] || 'text-gray-600'}>
+      {tracking.status.replace('_', ' ')} -
+      <span className="ml-1">{formatDate(tracking.estimatedDelivery)}</span>
+    </span>
+  );
+};

--- a/ups-tracker-dashboard/package.json
+++ b/ups-tracker-dashboard/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ups-tracker-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node-dev --respawn server.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.4.2",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.2.2",
+    "tailwindcss": "^3.3.2"
+  }
+}

--- a/ups-tracker-dashboard/pages/index.tsx
+++ b/ups-tracker-dashboard/pages/index.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { Device, TrackingInfo } from '../types';
+import { DeviceTable } from '../components/DeviceTable';
+
+export default function IndexPage() {
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [trackings, setTrackings] = useState<Record<string, TrackingInfo>>({});
+
+  useEffect(() => {
+    fetch('/api/getDevices')
+      .then(res => res.json())
+      .then((data: Device[]) => {
+        setDevices(data);
+        data.forEach(device => {
+          if (device.trackingNumber) {
+            fetch(`/api/getTracking?trackingNumber=${device.trackingNumber}`)
+              .then(res => res.json())
+              .then((info: TrackingInfo) =>
+                setTrackings(prev => ({ ...prev, [device.trackingNumber!]: info }))
+              )
+              .catch(() => {});
+          }
+        });
+      });
+  }, []);
+
+  return (
+    <main className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Device Dashboard</h1>
+      <DeviceTable devices={devices} trackings={trackings} />
+    </main>
+  );
+}

--- a/ups-tracker-dashboard/server.ts
+++ b/ups-tracker-dashboard/server.ts
@@ -1,0 +1,27 @@
+import express from 'express';
+import path from 'path';
+import { getDevices } from './api/getDevices';
+import { getTracking } from './api/getTracking';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Static files (React build output would go here after running `npm run build`)
+app.use(express.static(path.join(__dirname, 'build')));
+
+app.get('/api/getDevices', getDevices);
+app.get('/api/getTracking', getTracking);
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+
+// To test locally with mock data:
+// 1. Run `npm install`
+// 2. Execute `npm run dev`
+// 3. Visit http://localhost:3000/api/getDevices
+
+// TODO: Add Addigy API authentication middleware
+// TODO: Integrate UPS API key for real tracking data
+// TODO: Implement login system for MSP clients to view their devices
+// TODO: Add filtering by delivery status or customer

--- a/ups-tracker-dashboard/tailwind.config.js
+++ b/ups-tracker-dashboard/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/ups-tracker-dashboard/tsconfig.json
+++ b/ups-tracker-dashboard/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "build"
+  },
+  "include": ["api/**/*", "components/**/*", "pages/**/*", "utils/**/*", "types/**/*", "server.ts" ]
+}

--- a/ups-tracker-dashboard/types/index.ts
+++ b/ups-tracker-dashboard/types/index.ts
@@ -1,0 +1,13 @@
+export interface Device {
+  id: string;
+  name: string;
+  serialNumber: string;
+  addigyStatus: string;
+  trackingNumber?: string;
+}
+
+export interface TrackingInfo {
+  trackingNumber: string;
+  status: 'delivered' | 'in_transit' | 'exception' | 'unknown';
+  estimatedDelivery: string; // ISO date string
+}

--- a/ups-tracker-dashboard/utils/formatDate.ts
+++ b/ups-tracker-dashboard/utils/formatDate.ts
@@ -1,0 +1,8 @@
+export function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold React+TS UPS dashboard
- mock Addigy and UPS device APIs
- track device status and delivery info
- show future TODO comments
- add tsconfig build fixes

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68557841ecd88329b5faff4e6fa42c64