### PR TITLE
Add dashboard with status summary

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,6 @@
+import Dashboard from '../components/Dashboard'
+
 export default function Home() {
-  return (
-    <main className="p-8 text-center text-xl font-semibold border border-red-500">
-      🚚 UPS Tracker Dashboard — Coming Soon!
-    </main>
-  );
+  return <Dashboard />
 }
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,32 @@
+import StatusSummary from './StatusSummary'
+
+interface Device {
+  id: string
+  name: string
+  serial: string
+  status: 'active' | 'inactive'
+  trackingNumber: string
+}
+
+async function getDevices(): Promise<Device[]> {
+  try {
+    const res = await fetch('http://localhost:3000/api/devices', { cache: 'no-store' })
+    if (!res.ok) throw new Error('Failed to fetch')
+    return res.json()
+  } catch {
+    return []
+  }
+}
+
+export default async function Dashboard() {
+  const devices = await getDevices()
+  const inUse = devices.filter(d => d.status === 'active').length
+  const ready = devices.filter(d => d.status === 'inactive').length
+  const out = 0
+
+  return (
+    <div className="p-8 space-y-8">
+      <StatusSummary inUse={inUse} readyForUse={ready} outOfService={out} />
+    </div>
+  )
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -25,7 +25,8 @@ export default async function Dashboard() {
   const out = 0
 
   return (
-    <div className="p-8 space-y-8">
+    <div className="max-w-4xl mx-auto p-8 space-y-8">
+      <h1 className="text-2xl font-semibold text-gray-800">Device Status</h1>
       <StatusSummary inUse={inUse} readyForUse={ready} outOfService={out} />
     </div>
   )

--- a/src/components/StatusSummary.tsx
+++ b/src/components/StatusSummary.tsx
@@ -8,18 +8,18 @@ interface Props {
 
 export default function StatusSummary({ inUse, readyForUse, outOfService }: Props) {
   return (
-    <div className="grid gap-4 sm:grid-cols-3">
-      <div className="bg-white border-l-4 border-blue-600 p-4 rounded shadow">
-        <p className="text-sm text-gray-500">In Use</p>
-        <p className="mt-2 text-2xl font-bold text-blue-600">{inUse}</p>
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+      <div className="bg-white p-6 rounded-lg shadow border-t-4 border-blue-500 text-center">
+        <p className="text-sm font-medium text-gray-500">In Use</p>
+        <p className="mt-2 text-3xl font-bold text-blue-600">{inUse}</p>
       </div>
-      <div className="bg-white border-l-4 border-yellow-500 p-4 rounded shadow">
-        <p className="text-sm text-gray-500">Ready for Use</p>
-        <p className="mt-2 text-2xl font-bold text-yellow-600">{readyForUse}</p>
+      <div className="bg-white p-6 rounded-lg shadow border-t-4 border-orange-500 text-center">
+        <p className="text-sm font-medium text-gray-500">Ready for Use</p>
+        <p className="mt-2 text-3xl font-bold text-orange-600">{readyForUse}</p>
       </div>
-      <div className="bg-white border-l-4 border-gray-500 p-4 rounded shadow">
-        <p className="text-sm text-gray-500">Out of Service</p>
-        <p className="mt-2 text-2xl font-bold text-gray-600">{outOfService}</p>
+      <div className="bg-white p-6 rounded-lg shadow border-t-4 border-gray-500 text-center">
+        <p className="text-sm font-medium text-gray-500">Out of Service</p>
+        <p className="mt-2 text-3xl font-bold text-gray-600">{outOfService}</p>
       </div>
     </div>
   )

--- a/src/components/StatusSummary.tsx
+++ b/src/components/StatusSummary.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+interface Props {
+  inUse: number
+  readyForUse: number
+  outOfService: number
+}
+
+export default function StatusSummary({ inUse, readyForUse, outOfService }: Props) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      <div className="bg-white border-l-4 border-blue-600 p-4 rounded shadow">
+        <p className="text-sm text-gray-500">In Use</p>
+        <p className="mt-2 text-2xl font-bold text-blue-600">{inUse}</p>
+      </div>
+      <div className="bg-white border-l-4 border-yellow-500 p-4 rounded shadow">
+        <p className="text-sm text-gray-500">Ready for Use</p>
+        <p className="mt-2 text-2xl font-bold text-yellow-600">{readyForUse}</p>
+      </div>
+      <div className="bg-white border-l-4 border-gray-500 p-4 rounded shadow">
+        <p className="text-sm text-gray-500">Out of Service</p>
+        <p className="mt-2 text-2xl font-bold text-gray-600">{outOfService}</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a `StatusSummary` component for device counts
- create a server `Dashboard` component that fetches device data
- replace the homepage placeholder with the dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685eb725b4c88329b519dfbf126a23f6